### PR TITLE
Move some hardcoded values to laravel_newsletter.php config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This wil publish a file `laravel-newsletter.php` in your config directory with t
 return [
 
     'mailChimp' => [
-    
+
         /*
          * The api key of a MailChimp account. You can find yours here:
          * https://us10.admin.mailchimp.com/account/api-key-popup/
@@ -60,7 +60,7 @@ return [
          * send campaigns.
          */
         'lists' => [
-        
+
             /*
              * This key is used to identify this list. It can be used
              * in the various methods provided by this package.
@@ -68,9 +68,8 @@ return [
              * You can set it to any string you want and you can add
              * as many lists as you want.
              */
-             
             'subscribers' => [
-            
+
                 /*
                  * A mail chimp list id. Check the mailchimp docs if you don't know
                  * how to get this value:
@@ -81,9 +80,27 @@ return [
                 /*
                  * These values will be used when creating a new campaign.
                  */
-                'fromEmail' => '',
-                'fromName' => '',
-                'toName' => '',
+                'createCampaign' => [
+                    'fromEmail' => 'newsletter@coffeewithcats.com',
+                    'fromName' => 'coffee with cats',
+                    'toName' => ''
+                ],
+                /*
+                 * These values will be used when subscribing to a list
+                 */
+                'subscribe' => [
+                    'emailType' => 'html',
+                    'requireDoubleOptin' => false,
+                    'updateExistingUser' => false
+                ],
+                /*
+                 * These values will be used when unsubscribing from a list
+                 */
+                'unsubscribe' => [
+                    'deletePermanently' => false,
+                    'sendGoodbyeEmail' => false,
+                    'sendUnsubscribeEmail' => false
+                ],
             ],
         ],
     ],

--- a/src/MailChimp/NewsletterCampaign.php
+++ b/src/MailChimp/NewsletterCampaign.php
@@ -22,9 +22,9 @@ class NewsletterCampaign extends MailChimpBase implements NewsletterCampaignInte
             [
                 'list_id' => $listProperties['id'],
                 'subject' => $subject,
-                'from_email' => $listProperties['fromEmail'],
-                'from_name' => $listProperties['fromName'],
-                'to_name' => $listProperties['toName'],
+                'from_email' => $listProperties['createCampaign']['fromEmail'],
+                'from_name' => $listProperties['createCampaign']['fromName'],
+                'to_name' => $listProperties['createCampaign']['toName'],
 
             ],
             [

--- a/src/MailChimp/NewsletterList.php
+++ b/src/MailChimp/NewsletterList.php
@@ -28,9 +28,9 @@ class NewsletterList extends MailChimpBase implements NewsletterListInterface
                 $listProperties['id'],
                 compact('email'),
                 null,    //merge vars
-                'html',  //e-mail type
-                false,   //require double optin
-                false    //update existing user
+                $listProperties['subscribe']['emailType'],  //e-mail type
+                $listProperties['subscribe']['requireDoubleOptin'],   //require double optin
+                $listProperties['subscribe']['updateExistingUser']    //update existing user
             );
         } catch (\Mailchimp_List_AlreadySubscribed $exception) {
             throw new AlreadySubscribed();
@@ -54,9 +54,9 @@ class NewsletterList extends MailChimpBase implements NewsletterListInterface
         return $this->mailChimp->lists->unsubscribe(
             $listProperties['id'],
             compact('email'),
-            false,  //delete permanently
-            false,  //send goodbye mail?
-            false   //send unsubscribe mail?
+            $listProperties['unsubscribe']['deletePermanently'],  //delete permanently
+            $listProperties['unsubscribe']['sendGoodbyeEmail'],  //send goodbye mail?
+            $listProperties['unsubscribe']['sendUnsubscribeEmail']   //send unsubscribe mail?
         );
     }
 }

--- a/src/config/laravel-newsletter.php
+++ b/src/config/laravel-newsletter.php
@@ -35,9 +35,27 @@ return [
                 /*
                  * These values will be used when creating a new campaign.
                  */
-                'fromEmail' => '',
-                'fromName' => '',
-                'toName' => '',
+                'createCampaign' => [
+                    'fromEmail' => '',
+                    'fromName' => '',
+                    'toName' => ''
+                ],
+                /*
+                 * These values will be used when subscribing to a list
+                 */
+                'subscribe' => [
+                    'emailType' => 'html',
+                    'requireDoubleOptin' => false,
+                    'updateExistingUser' => false
+                ],
+                /*
+                 * These values will be used when unsubscribing from a list
+                 */
+                'unsubscribe' => [
+                    'deletePermanently' => false,
+                    'sendGoodbyeEmail' => false,
+                    'sendUnsubscribeEmail' => false
+                ],
             ],
         ],
     ],


### PR DESCRIPTION
I needed to subscribe my users to the list using `doubleoptin` enabled.
Then realized this value (and some others) were hardcoded

So I moved most of these values (not sure about the `merge`option) to the config file