### PR TITLE
Remove stray lastActionSucceeded(), there is no prior API call

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -70,10 +70,6 @@ class Newsletter
     {
         $list = $this->lists->findByName($listName);
 
-        if (! $this->lastActionSucceeded()) {
-            return false;
-        }
-
         return $this->mailChimp->get("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}");
     }
 


### PR DESCRIPTION
See #38   Underlying drewm/mailchimp-api class updates & caches member variable last_error only when API call is made.  When no API call is made, prior cached value is returned which was causing false failure in getMember() check.  Its possible you had intended this:

```
        $response = $this->mailChimp->get("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}");

        if (! $this->lastActionSucceeded()) {
            return false;
        }

        return $response;
```

as that pattern is used elsewhere, but figured I'd start with a change that fixes the issue and doesn't alter the getMember() response.