### PR TITLE
Add method to delete subscriber from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ You can also unsubscribe someone from a specific list:
 Newsletter::unsubscribe('rincewind@discworld.com', 'subscribers');
 ```
 
+### Deleting subscribers
+
+NOTE: Deleting is not the same as unsubscribing. Deleting loses all history (add/opt-in/edits) as well as removing them from the list. Unlike an unsubscribe, they can still be added back again later. This is for list-maintenance only. 
+If a subscriber is "opting out", you should `unsubscribe` instead!
+
+To delete a subscriber's record from the list permanently:
+```php
+Newsletter::delete('rincewind@discworld.com');
+```
+
 ### Getting subscriber info
 
 You can get information on a subscriber by using the `getMember` function:

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -114,6 +114,23 @@ class Newsletter
     }
 
     /**
+     * @param $email
+     * @param string $listName
+     *
+     * @return array|false
+     *
+     * @throws \Spatie\Newsletter\Exceptions\InvalidNewsletterList
+     */
+    public function delete($email, $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        $response = $this->mailChimp->delete("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}");
+
+        return $response;
+    }
+
+    /**
      * @param string $fromName
      * @param string $replyTo
      * @param string $subject

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -179,6 +179,46 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_delete_someone()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('delete')
+            ->once()
+            ->withArgs(["lists/123/members/{$subscriberHash}"]);
+
+        $this->newsletter->delete('freek@spatie.be');
+    }
+
+    /** @test */
+    public function it_can_delete_someone_from_a_specific_list()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('delete')
+            ->once()
+            ->withArgs(["lists/456/members/{$subscriberHash}"]);
+
+        $this->newsletter->delete('freek@spatie.be', 'list2');
+    }
+
+    /** @test */
     public function it_exposes_the_api()
     {
         $api = $this->newsletter->getApi();


### PR DESCRIPTION
To differentiate meanings:

`delete()` is for removing someone from the list ... ie: list maintenance

`unsubscribe()` is for telling your list that the subscriber has opted-out and should not be emailed again