### PR TITLE
Add MAILCHIMP_SSL env configuration

### DIFF
--- a/config/laravel-newsletter.php
+++ b/config/laravel-newsletter.php
@@ -7,6 +7,11 @@ return [
          * https://us10.admin.mailchimp.com/account/api-key-popup/
          */
         'apiKey' => env('MAILCHIMP_APIKEY'),
+        
+        /*
+         * Use HTTP or HTTPS protocol
+         */
+        'ssl' => env('MAILCHIMP_SSL', true),
 
         /*
          * When not specifying a listname in the various methods, use the list with this name

--- a/src/NewsletterServiceProvider.php
+++ b/src/NewsletterServiceProvider.php
@@ -22,6 +22,8 @@ class NewsletterServiceProvider extends ServiceProvider
     {
         $this->app->singleton(Newsletter::class, function () {
             $mailChimp = new Mailchimp(config('laravel-newsletter.apiKey'));
+            
+            $mailChimp->verify_ssl = config('laravel-newsletter.ssl');
 
             $configuredLists = NewsletterListCollection::createFromConfig(config('laravel-newsletter'));
 


### PR DESCRIPTION
Possibility to configure the usage of SSL or not in laravel-newsletter configuration via MAILCHIMP_SSL environment configuration. Default = true.