### PR TITLE
Update existing email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Newsletter::subscribe('nanny.ogg@discworld.com', ['firstName'=>'Nanny', 'lastNam
 //Subscribe or update someone
 Newsletter::subscribeOrUpdate('sam.vines@discworld.com', ['firstName'=>'Foo', 'lastName'=>'Bar']);
 
+// Change the email address of an existing subscriber
+Newsletter:updateEmailAddress('rincewind@discworld.com', 'the.luggage@discworld.com');
+
 //Get some member info, returns an array described in the official docs
 Newsletter::getMember('lord.vetinari@discworld.com');
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Newsletter::subscribe('nanny.ogg@discworld.com', ['firstName'=>'Nanny', 'lastNam
 Newsletter::subscribeOrUpdate('sam.vines@discworld.com', ['firstName'=>'Foo', 'lastName'=>'Bar']);
 
 // Change the email address of an existing subscriber
-Newsletter:updateEmailAddress('rincewind@discworld.com', 'the.luggage@discworld.com');
+Newsletter::updateEmailAddress('rincewind@discworld.com', 'the.luggage@discworld.com');
 
 //Get some member info, returns an array described in the official docs
 Newsletter::getMember('lord.vetinari@discworld.com');

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -129,7 +129,7 @@ class Newsletter
     }
     
     /**
-     * Update the email address of an existing list member
+     * Update the email address of an existing list member.
      *
      * @param string $currentEmailAddress
      * @param string $newEmailAddress
@@ -144,7 +144,7 @@ class Newsletter
         $list = $this->lists->findByName($listName);
         
         $response = $this->mailChimp->patch("lists/{$list->getId()}/members/{$this->getSubscriberHash($currentEmailAddress)}", [
-            'email_address' => $newEmailAddress
+            'email_address' => $newEmailAddress,
         ]);
         
         return $response;

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -127,6 +127,28 @@ class Newsletter
 
         return $response;
     }
+    
+    /**
+     * Update the email address of an existing list member
+     *
+     * @param string $currentEmailAddress
+     * @param string $newEmailAddress
+     * @param string $listName
+     *
+     * @return array|false
+     *
+     * @throws \Spatie\Newsletter\Exceptions\InvalidNewsletterList
+     */
+    public function updateEmailAddress($currentEmailAddress, $newEmailAddress, $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+        
+        $response = $this->mailChimp->patch("lists/{$list->getId()}/members/{$this->getSubscriberHash($currentEmailAddress)}", [
+            'email_address' => $newEmailAddress
+        ]);
+        
+        return $response;
+    }
 
     /**
      * @param $email

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -127,7 +127,7 @@ class Newsletter
 
         return $response;
     }
-    
+
     /**
      * Update the email address of an existing list member.
      *

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -142,11 +142,11 @@ class Newsletter
     public function updateEmailAddress($currentEmailAddress, $newEmailAddress, $listName = '')
     {
         $list = $this->lists->findByName($listName);
-        
+
         $response = $this->mailChimp->patch("lists/{$list->getId()}/members/{$this->getSubscriberHash($currentEmailAddress)}", [
             'email_address' => $newEmailAddress,
         ]);
-        
+
         return $response;
     }
 

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -256,12 +256,13 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
             ->withArgs([$email])
             ->andReturn($subscriberHash);
 
-        $this->mailChimpApi->shouldReceive('patch')
+        $this->mailChimpApi
+            ->shouldReceive('patch')
             ->once()
             ->withArgs([
                 "{$url}/{$subscriberHash}",
                 [
-                    'email_address' => $email,
+                    'email_address' => $newEmail,
                 ],
             ]);
 

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -240,7 +240,7 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
 
         $this->newsletter->subscribeOrUpdate($email, [], '', ['email_type' => 'text', 'status' => 'pending']);
     }
-    
+
     /** @test */
     public function it_can_change_the_email_address_of_a_subscriber()
     {
@@ -265,7 +265,7 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
                 ],
             ]);
 
-        $this->newsletter->updateEmailAddress($email, $newEmail);        
+        $this->newsletter->updateEmailAddress($email, $newEmail);
     }
 
     /** @test */

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -240,6 +240,33 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
 
         $this->newsletter->subscribeOrUpdate($email, [], '', ['email_type' => 'text', 'status' => 'pending']);
     }
+    
+    /** @test */
+    public function it_can_change_the_email_address_of_a_subscriber()
+    {
+        $email = 'freek@spatie.be';
+        $newEmail = 'phreak@spatie.be';
+
+        $url = 'lists/123/members';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi->shouldReceive('patch')
+            ->once()
+            ->withArgs([
+                "{$url}/{$subscriberHash}",
+                [
+                    'email_address' => $email,
+                ],
+            ]);
+
+        $this->newsletter->updateEmailAddress($email, $newEmail);        
+    }
 
     /** @test */
     public function it_can_unsubscribe_someone()


### PR DESCRIPTION
It currently is not possible to directly update the email address of an existing subscriber without using `getApi()` directly. 

This pull requests implements a simple method to do exactly this.