### PR TITLE
Implemented getMembers() and getMemberActivity()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Newsletter::updateEmailAddress('rincewind@discworld.com', 'the.luggage@discworld
 //Get some member info, returns an array described in the official docs
 Newsletter::getMember('lord.vetinari@discworld.com');
 
+//Get the member activity, returns an array with recent activity for a given user
+Newsletter::getMemberActivity('lord.vetinari@discworld.com');
+
+//Get the members for a given list, optionally filtered by passing a second array of parameters
+Newsletter::getMembers();
+
 //Returns a boolean
 Newsletter::hasMember('greebo@discworld.com');
 

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -74,6 +74,19 @@ class Newsletter
     }
 
     /**
+     * @param string $listName
+     *
+     * @param array $parameters
+     * @return array|bool
+     */
+    public function getMembers($listName = '', $parameters = [])
+    {
+        $list = $this->lists->findByName($listName);
+
+        return $this->mailChimp->get("lists/{$list->getId()}/members", $parameters);
+    }
+
+    /**
      * @param string $email
      * @param string $listName
      *
@@ -86,6 +99,21 @@ class Newsletter
         $list = $this->lists->findByName($listName);
 
         return $this->mailChimp->get("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}");
+    }
+
+    /**
+     * @param string $email
+     * @param string $listName
+     *
+     * @return array|bool
+     *
+     * @throws \Spatie\Newsletter\Exceptions\InvalidNewsletterList
+     */
+    public function getMemberActivity($email, $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        return $this->mailChimp->get("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/activity");
     }
 
     /**
@@ -215,6 +243,12 @@ class Newsletter
         return $response;
     }
 
+    /**
+     * @param $campaignId
+     * @param $html
+     * @param array $options
+     * @return array|bool|false
+     */
     public function updateContent($campaignId, $html, $options = [])
     {
         $defaultOptions = compact('html');

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -368,6 +368,17 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_get_the_list_members()
+    {
+        $this->mailChimpApi
+            ->shouldReceive('get')
+            ->once()
+            ->withArgs(["lists/123/members", []]);
+
+        $this->newsletter->getMembers();
+    }
+
+    /** @test */
     public function it_can_get_the_member()
     {
         $email = 'freek@spatie.be';
@@ -385,6 +396,26 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
             ->withArgs(["lists/123/members/{$subscriberHash}"]);
 
         $this->newsletter->getMember($email);
+    }
+
+    /** @test */
+    public function it_can_get_the_member_activity()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('get')
+            ->once()
+            ->withArgs(["lists/123/members/{$subscriberHash}/activity"]);
+
+        $this->newsletter->getMemberActivity($email);
     }
 
     /** @test */

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -373,7 +373,7 @@ class NewsletterTest extends PHPUnit_Framework_TestCase
         $this->mailChimpApi
             ->shouldReceive('get')
             ->once()
-            ->withArgs(["lists/123/members", []]);
+            ->withArgs(['lists/123/members', []]);
 
         $this->newsletter->getMembers();
     }


### PR DESCRIPTION
I was missing another two pieces of functionality so I implemented them :)

Use cases:

- `getMembers()` - allows you to retrieve an optionally-filtered list of members for a given list. Super handy if you want to update local props based on MailChimp activity
- `getMemberActivity()` - allows you to see specific information regarding (amongst other things) received campaigns for a given list member