### PR TITLE
Added fix for checking if hasMember.

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -126,7 +126,7 @@ class Newsletter
     {
         $response = $this->getMember($email, $listName);
 
-        if (! isset($response['email_address'])) {
+        if (! ($response['status'] == 'subscribed')) {
             return false;
         }
 


### PR DESCRIPTION
It no longer returns true every time due to the fact that before the lookup searched for the email address was present in the response.

The only time this would work as expected is if someone called this function prior to adding them to the list. Once added to the list it would always be present no matter the subscription status, therefore returning true, even if the user was unsubscribed from the list

Maybe I'm thinking about this wrong but essentially, it would always return true even if a user was unsubscribed, is someone able to test to confirm this? It is what I have observed.