### PR TITLE
Fix lastActionSucceeded check.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php" : "~5.6|~7.0",
         "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "drewm/mailchimp-api": "^2.1"
+        "drewm/mailchimp-api": "^2.4"
     },
     "require-dev": {
         "phpunit/phpunit" : "^5.0",

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -285,7 +285,7 @@ class Newsletter
      */
     public function lastActionSucceeded()
     {
-        return ! $this->mailChimp->getLastError();
+        return $this->mailChimp->success();
     }
 
     /**


### PR DESCRIPTION
This change swaps the success check to use the success method in the underlying MailChimp php library: https://github.com/drewm/mailchimp-api/blob/master/src/MailChimp.php#L87

This fixes an issue where after an error occurs all further requests would return false as the error is not purged.

fixes #92 