### PR TITLE
Fix NewsletterFacade getFacadeAccessor method.

### DIFF
--- a/src/NewsletterFacade.php
+++ b/src/NewsletterFacade.php
@@ -8,6 +8,6 @@ class NewsletterFacade extends Facade
 {
     public static function getFacadeAccessor()
     {
-        return 'laravel-newsletter';
+        return 'newsletter';
     }
 }


### PR DESCRIPTION
Fixes ```ReflectionException: Class laravel-newsletter does not exist``` errors.