### PR TITLE
Pending subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Newsletter::subscribe('sam.vines@discworld.com', ['firstName'=>'Sam', 'lastName'
 //Subscribe someone to a specific list by using the third argument:
 Newsletter::subscribe('nanny.ogg@discworld.com', ['firstName'=>'Nanny', 'lastName'=>'Ogg'], 'Name of your list');
 
+//Subscribe someone to a specific list and require them to confirm via email:
+Newsletter::subscribePending('nanny.ogg@discworld.com', ['firstName'=>'Nanny', 'lastName'=>'Ogg'], 'Name of your list');
+
 //Subscribe or update someone
 Newsletter::subscribeOrUpdate('sam.vines@discworld.com', ['firstName'=>'Foo', 'lastName'=>'Bar']);
 
@@ -157,7 +160,7 @@ You can also subscribe and/or update someone. The person will be subscribed or u
  ```php
  Newsletter::subscribeOrUpdate('rincewind@discworld.com', ['firstName'=>'Foo', 'lastname'=>'Bar']);
  ```
- 
+
 You can subscribe someone to one or more specific group(s)/interest(s) by using the fourth argument:
 
 ```php

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -38,7 +38,7 @@ class Newsletter
     {
         $options = array_merge($options, ['status' => 'pending']);
 
-        return $this->subscribe($email, $mergeFields, $listName, );
+        return $this->subscribe($email, $mergeFields, $listName, $options);
     }
 
     public function subscribeOrUpdate(string $email, array $mergeFields = [], string $listName = '', array $options = [])

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -34,11 +34,18 @@ class Newsletter
         return $response;
     }
 
+    public function subscribePending(string $email, array $mergeFields = [], string $listName = '', array $options = [])
+    {
+        $options = array_merge($options, ['status' => 'pending']);
+
+        return $this->subscribe($email, $mergeFields, $listName, );
+    }
+
     public function subscribeOrUpdate(string $email, array $mergeFields = [], string $listName = '', array $options = [])
     {
         $list = $this->lists->findByName($listName);
 
-        $options = $this->getSubscriptionOptions($email, $mergeFields, $options);
+        $options = $this->getSubscriptionOptions($email, $mergeFields, $options, $options);
 
         $response = $this->mailChimp->put("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}", $options);
 

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -67,6 +67,25 @@ class NewsletterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_subscribe_someone_as_pending()
+    {
+        $email = 'freek@spatie.be';
+
+        $url = 'lists/123/members';
+
+        $this->mailChimpApi->shouldReceive('post')->withArgs([
+            $url,
+            [
+                'email_address' => $email,
+                'status' => 'pending',
+                'email_type' => 'html',
+            ],
+        ]);
+
+        $this->newsletter->subscribe($email);
+    }
+
+    /** @test */
     public function it_can_subscribe_or_update_someone()
     {
         $email = 'freek@spatie.be';

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -82,7 +82,7 @@ class NewsletterTest extends TestCase
             ],
         ]);
 
-        $this->newsletter->subscribe($email);
+        $this->newsletter->subscribePending($email);
     }
 
     /** @test */


### PR DESCRIPTION
**What it Does:**
This pull request adds a new helper method to add a newsletter subscription while setting the status to pending, this will require the individual to confirm their subscription via email.

**Side Note:**
I have not included a helper for the subscribeOrUpdate method, this would introduce the possibility of setting an already confirmed subscription back to pending, if this is requested this could be accomplished safely by checking if the email is subscribed to the list before merging the options.