### PR TITLE
Adds subscribePending helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-All Notable changes to `laravel-newsletter` will be documented in this file
+All notable changes to `laravel-newsletter` will be documented in this file
+
+## 3.6.0 - 2017-06-29
+
+- add `getMembers` and `getMemberActivity`
 
 ## 3.5.0 - 2017-06-23
 


### PR DESCRIPTION
**What it Does:**
This pull request adds a new helper method to add a newsletter subscription while setting the status to pending, this will require the individual to confirm their subscription via email.

**Changes:**
- Adds new method subscribePending to newsletter class
- Updates the readme the reflect the new helper method
- Adds a test for the new functionality

**Side Note:**
I have not included a helper for the subscribeOrUpdate method, this would introduce the possibility of setting an already confirmed subscription back to pending, if this is requested this could be accomplished safely by checking if the email is subscribed to the list before merging the options.