### PR TITLE
Update for config file docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ composer require spatie/laravel-newsletter
 
 The package will automatically register itself.
 
-To publish the config file to `app/config/laravel-newsletter.php` run:
+To publish the config file to `config/newsletter.php` run:
 
 ```bash
 php artisan vendor:publish --provider="Spatie\Newsletter\NewsletterServiceProvider"


### PR DESCRIPTION
since 4.0 the config file is changed to `config/newsletter.php`