### PR TITLE
Update composer.json to include illuminate/support ~5.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php" : "~7.0",
-        "illuminate/support": "~5.5.0",
+        "illuminate/support": "~5.5.0||~5.6.0",
         "drewm/mailchimp-api": "^2.4"
     },
     "require-dev": {

--- a/src/NewsletterListCollection.php
+++ b/src/NewsletterListCollection.php
@@ -10,7 +10,7 @@ class NewsletterListCollection extends Collection
     /** @var string */
     public $defaultListName = '';
 
-    public static function createFromConfig(array $config): NewsletterListCollection
+    public static function createFromConfig(array $config): self
     {
         $collection = new static();
 


### PR DESCRIPTION
I saw the other pull request, but I don't see the reason of dropping compatibility with the older version.