### PR TITLE
unsubscribe() returns array when it fails

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -114,6 +114,10 @@ class Newsletter
         $response = $this->mailChimp->patch("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}", [
             'status' => 'unsubscribed',
         ]);
+        
+        if (! $this->lastActionSucceeded()) {
+            return false;
+        }
 
         return $response;
     }


### PR DESCRIPTION
Hi guys,

When unsubscribe() fails it returns an array with the response and it gets interpreted as "true" by PHP.
In think that it should return false to be in concordance with the 'subscribe' method of the class, which returns false when it fails, and then if you want to get more info you use getLastError().

Thank you for all!

