### PR TITLE
Throw exceptions when a call to the underlying API fails

### DIFF
--- a/src/Exceptions/FailedResponse.php
+++ b/src/Exceptions/FailedResponse.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Newsletter\Exceptions;
+
+use Exception;
+
+class FailedResponse extends Exception
+{
+    public $response;
+    
+    public function __construct($response)
+    {
+        $this->response = $response;
+    }
+}


### PR DESCRIPTION
Consumers of the package might need to know the reason behind a failed response of the underlying API. 

Currently the package returns `false` when encountering such responses. With the changes below a `FailedResponse` exception is thrown that contains the original response coming from the underlying API. 

This is a breaking change, but you might consider merging this in with the next major version.