### PR TITLE
Add method to patch member with pending status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Newsletter::subscribePending('nanny.ogg@discworld.com', ['firstName'=>'Nanny', '
 //Subscribe or update someone
 Newsletter::subscribeOrUpdate('sam.vines@discworld.com', ['firstName'=>'Foo', 'lastName'=>'Bar']);
 
+//Update someone and apply pending status.
+Newsletter::updatePending('sam.vines@discworld.com', ['firstName'=>'Foo', 'lastName'=>'Bar']);
+
 // Change the email address of an existing subscriber
 Newsletter::updateEmailAddress('rincewind@discworld.com', 'the.luggage@discworld.com');
 
@@ -277,7 +280,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -56,6 +56,23 @@ class Newsletter
         return $response;
     }
 
+    public function updatePending(string $email, array $mergeFields = [], string $listName = '', array $options = [])
+    {
+        $options = array_merge($options, ['status' => 'pending']);
+
+        $list = $this->lists->findByName($listName);
+
+        $options = $this->getSubscriptionOptions($email, $mergeFields, $options);
+
+        $response = $this->mailChimp->patch("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}", $options);
+
+        if (! $this->lastActionSucceeded()) {
+            return false;
+        }
+
+        return $response;
+    }
+
     public function getMembers(string $listName = '', array $parameters = [])
     {
         $list = $this->lists->findByName($listName);

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -112,6 +112,32 @@ class NewsletterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_update_someone_and_set_pending_status()
+    {
+        $email = 'freek@spatie.be';
+
+        $url = 'lists/123/members';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi->shouldReceive('patch')->withArgs([
+            "{$url}/{$subscriberHash}",
+            [
+                'email_address' => $email,
+                'status' => 'pending',
+                'email_type' => 'html',
+            ],
+        ]);
+
+        $this->newsletter->updatePending($email);
+    }
+
+    /** @test */
     public function it_can_subscribe_someone_with_merge_fields()
     {
         $email = 'freek@spatie.be';


### PR DESCRIPTION
When a list has 'double opt-in' enabled and a member is added to a list with status set to pending the member is sent an email with a link to confirm their subscription.

It seems an existing member will only be sent this confirmation email again if a PATCH is sent to the resource. 

I propose adding an `updatePending ` method that will accept updates to the member as well as invoke the opt-in confirmation email to be resent.