### PR TITLE
Add support for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php" : "~7.0",
-        "illuminate/support": "~5.5.0|~5.6.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
         "drewm/mailchimp-api": "^2.4"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 5.7 isn't released yet, but some people are already using it. This PR allows the use of this package with Laravel 5.7

Also, please release a new version of this package (you can release a patch or a minor version) when you merge this PR, to avoid pulling `dev-master`. :wink:

:octocat: