### PR TITLE
Update Mailchimp list id link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ return [
             /*
              * A MailChimp list id. Check the MailChimp docs if you don't know
              * how to get this value:
-             * http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id.
+             * https://mailchimp.com/help/find-your-list-id/.
              */
             'id' => env('MAILCHIMP_LIST_ID'),
         ],


### PR DESCRIPTION
The help page has moved.
The `kb.mailchimp...` gives a 301 and directs to the new page, but I think it seems best to link to the new one.