### PR TITLE
Add helpers for manage member tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Newsletter::isSubscribed('rincewind@discworld.com');
 //Returns a boolean
 Newsletter::hasMember('greebo@discworld.com');
 
+// Get the tags for a member in a given list
+Newsletter::getTags('lord.vetinari@discworld.com');
+
+// Add tags for a member in a given list, any new tags will be created
+Newsletter::addTags(['tag-1', 'tag-2'], 'lord.vetinari@discworld.com');
+
+// Remove tags for a member in a given list, any new tags will be created
+Newsletter::removeTags(['tag-1', 'tag-2'], 'lord.vetinari@discworld.com');
+
 //If you want to do something else, you can get an instance of the underlying API:
 Newsletter::getApi();
 ```

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -142,6 +142,39 @@ class Newsletter
         return $response;
     }
 
+    public function getTags(string $email, string $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        return $this->mailChimp->get("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/tags");
+    }
+
+    public function addTags(array $tags, string $email, string $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        $payload = collect($tags)->mapWithKeys(function ($tag) {
+            return [$tag => 'active'];
+        })->toArray();
+
+        return $this->mailChimp->post("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/tags", [
+            'tags' => $payload,
+        ]);
+    }
+
+    public function removeTags(array $tags, string $email, string $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        $payload = collect($tags)->mapWithKeys(function ($tag) {
+            return [$tag => 'inactive'];
+        })->toArray();
+
+        return $this->mailChimp->post("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/tags", [
+            'tags' => $payload,
+        ]);
+    }
+
     public function createCampaign(
         string $fromName,
         string $replyTo,

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -509,4 +509,73 @@ class NewsletterTest extends TestCase
 
         $this->newsletter->createCampaign($fromName, $replyTo, $subject, $html, $listName, $options, $contentOptions);
     }
+
+    /** @test */
+    public function it_can_get_member_tags()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('get')
+            ->once()
+            ->withArgs(["lists/123/members/{$subscriberHash}/tags"])
+            ->andReturn('all-the-member-tags');
+
+        $actual = $this->newsletter->getTags($email);
+
+        $this->assertSame('all-the-member-tags', $actual);
+    }
+
+    /** @test */
+    public function it_can_add_member_tags()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('post')
+            ->once()
+            ->withArgs(["lists/123/members/{$subscriberHash}/tags", ['tags' => ['tag-1' => 'active', 'tag-2' => 'active']]])
+            ->andReturn('the-post-response');
+
+        $actual = $this->newsletter->addTags(['tag-1', 'tag-2'], $email);
+
+        $this->assertSame('the-post-response', $actual);
+    }
+
+    /** @test */
+    public function it_can_remove_member_tags()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('post')
+            ->once()
+            ->withArgs(["lists/123/members/{$subscriberHash}/tags", ['tags' => ['tag-1' => 'inactive', 'tag-2' => 'inactive']]])
+            ->andReturn('the-post-response');
+
+        $actual = $this->newsletter->removeTags(['tag-1', 'tag-2'], $email);
+
+        $this->assertSame('the-post-response', $actual);
+    }
 }

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -462,7 +462,7 @@ class NewsletterTest extends TestCase
     }
 
     /** @test */
-    public function is_can_create_a_campaign()
+    public function it_can_create_a_campaign()
     {
         $fromName = 'Spatie';
         $replyTo = 'info@spatie.be';


### PR DESCRIPTION
Tags provides an additional way to filter members within a list. It's common to use tags to track member progress or events within an application. This adds the ability to retrieve, add, and remove tags from members within a list.