### PR TITLE
Correct tag payload format

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -153,8 +153,8 @@ class Newsletter
     {
         $list = $this->lists->findByName($listName);
 
-        $payload = collect($tags)->mapWithKeys(function ($tag) {
-            return [$tag => 'active'];
+        $payload = collect($tags)->map(function ($tag) {
+            return ['name' => $tag, 'status' => 'active'];
         })->toArray();
 
         return $this->mailChimp->post("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/tags", [
@@ -166,8 +166,8 @@ class Newsletter
     {
         $list = $this->lists->findByName($listName);
 
-        $payload = collect($tags)->mapWithKeys(function ($tag) {
-            return [$tag => 'inactive'];
+        $payload = collect($tags)->map(function ($tag) {
+            return ['name' => $tag, 'status' => 'inactive'];
         })->toArray();
 
         return $this->mailChimp->post("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/tags", [

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -548,7 +548,7 @@ class NewsletterTest extends TestCase
         $this->mailChimpApi
             ->shouldReceive('post')
             ->once()
-            ->withArgs(["lists/123/members/{$subscriberHash}/tags", ['tags' => ['tag-1' => 'active', 'tag-2' => 'active']]])
+            ->withArgs(["lists/123/members/{$subscriberHash}/tags", ['tags' => [['name' => 'tag-1', 'status' => 'active'], ['name' => 'tag-2', 'status' => 'active']]]])
             ->andReturn('the-post-response');
 
         $actual = $this->newsletter->addTags(['tag-1', 'tag-2'], $email);
@@ -571,7 +571,7 @@ class NewsletterTest extends TestCase
         $this->mailChimpApi
             ->shouldReceive('post')
             ->once()
-            ->withArgs(["lists/123/members/{$subscriberHash}/tags", ['tags' => ['tag-1' => 'inactive', 'tag-2' => 'inactive']]])
+            ->withArgs(["lists/123/members/{$subscriberHash}/tags", ['tags' => [['name' => 'tag-1', 'status' => 'inactive'], ['name' => 'tag-2', 'status' => 'inactive']]]])
             ->andReturn('the-post-response');
 
         $actual = $this->newsletter->removeTags(['tag-1', 'tag-2'], $email);


### PR DESCRIPTION
The payload was not _mapped_ correctly according to the API tag spec. While it worked for the tests, it did not work against the live API. I have updated to code and tests with the correct format and have been testing in production successfully for the last few days.