### PR TITLE
Create configureable driver

### DIFF
--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -3,6 +3,13 @@
 return [
 
     /*
+     * The driver to use to interact with MailChimp API.
+     * You may use "log" or "null" to prevent calling the
+     * API directly from your environment.
+     */
+    'driver' => env('MAILCHIMP_DRIVER', 'api'),
+
+    /*
      * The API key of a MailChimp account. You can find yours at
      * https://us10.admin.mailchimp.com/account/api-key-popup/.
      */

--- a/src/NewsletterServiceProvider.php
+++ b/src/NewsletterServiceProvider.php
@@ -21,6 +21,11 @@ class NewsletterServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(Newsletter::class, function () {
+            $driver = config('newsletter.driver', 'api');
+            if (is_null($driver) || $driver === 'log') {
+                return new NullDriver($driver === 'log');
+            }
+
             $mailChimp = new Mailchimp(config('newsletter.apiKey'));
 
             $mailChimp->verify_ssl = config('newsletter.ssl', true);

--- a/src/NullDriver.php
+++ b/src/NullDriver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\Newsletter;
+
+use Illuminate\Support\Facades\Log;
+
+class NullDriver
+{
+    /**
+     * @var bool
+     */
+    private $logCalls;
+
+    public function __construct(bool $logCalls = false)
+    {
+        $this->logCalls = $logCalls;
+    }
+
+    public function __call($name, $arguments)
+    {
+        if ($this->logCalls) {
+            Log::debug('Called Spatie Newsletter facade method: '.$name.' with:', $arguments);
+        }
+    }
+}

--- a/tests/MailChimp/NullDriverTest.php
+++ b/tests/MailChimp/NullDriverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\Newsletter\Test;
+
+use Spatie\Newsletter\NullDriver;
+use Illuminate\Support\Facades\Log;
+
+class NullDriverTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        \Mockery::close();
+    }
+
+    /** @test */
+    public function it_can_be_call_with_any_method()
+    {
+        $subject = new NullDriver();
+
+        $this->assertNull($subject->whatever());
+        $this->assertNull($subject->subscription());
+        $this->assertNull($subject->addTags('jason@testing.com', ['tags']));
+    }
+
+    /** @test */
+    public function it_logs_the_method_call_when_log_is_set()
+    {
+        $subject = new NullDriver(true);
+
+        $log = \Mockery::mock();
+        Log::swap($log);
+
+        $log->shouldReceive('debug')->twice();
+
+        $this->assertNull($subject->whatever());
+        $this->assertNull($subject->addTags('jason@testing.com', ['tags']));
+
+        $log->shouldHaveReceived('debug', ['Called Spatie Newsletter facade method: whatever with:', []]);
+        $log->shouldHaveReceived('debug', ['Called Spatie Newsletter facade method: addTags with:', ['jason@testing.com', ['tags']]]);
+    }
+}


### PR DESCRIPTION
This allows the developer to specify a "log" or "null" driver in order to avoid calling the MailChimp API directly from a lower environment since there is no "sandbox" MailChimp API.