### PR TITLE
Add the ability to permanent delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ Here's how to perform a delete:
 Newsletter::delete('rincewind@discworld.com');
 ```
 
+### Deleting subscribers permanently
+
+Delete all personally identifiable information related to a list member, and remove them from a list. This will make it impossible to re-import the list member.
+
+Here's how to perform a permanent delete:
+
+```php
+Newsletter::deletePermanently('rincewind@discworld.com');
+```
+
 ### Getting subscriber info
 
 You can get information on a subscriber by using the `getMember` function:

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -142,6 +142,15 @@ class Newsletter
         return $response;
     }
 
+    public function deletePermanently(string $email, string $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        $response = $this->mailChimp->post("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}/actions/delete-permanent");
+
+        return $response;
+    }
+
     public function getTags(string $email, string $listName = '')
     {
         $list = $this->lists->findByName($listName);

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -383,6 +383,46 @@ class NewsletterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_delete_someone_permanently()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('post')
+            ->once()
+            ->withArgs(["lists/123/members/{$subscriberHash}/actions/delete-permanent"]);
+
+        $this->newsletter->deletePermanently('freek@spatie.be');
+    }
+
+    /** @test */
+    public function it_can_delete_someone_permanently_from_a_specific_list()
+    {
+        $email = 'freek@spatie.be';
+
+        $subscriberHash = 'abc123';
+
+        $this->mailChimpApi->shouldReceive('subscriberHash')
+            ->once()
+            ->withArgs([$email])
+            ->andReturn($subscriberHash);
+
+        $this->mailChimpApi
+            ->shouldReceive('post')
+            ->once()
+            ->withArgs(["lists/456/members/{$subscriberHash}/actions/delete-permanent"]);
+
+        $this->newsletter->deletePermanently('freek@spatie.be', 'list2');
+    }
+
+    /** @test */
     public function it_exposes_the_api()
     {
         $api = $this->newsletter->getApi();


### PR DESCRIPTION
The API delete method only supports "delete and archive" so in order to permanently delete a subscriber from a list you require another endpoint.