### PR TITLE
Fix return type for getLastError

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -247,7 +247,7 @@ class Newsletter
     }
 
     /**
-     * @return array|false
+     * @return string|false
      */
     public function getLastError()
     {


### PR DESCRIPTION
The MailChimp class returns a `string` or `false` on `getLastError`. Please see https://github.com/drewm/mailchimp-api/blob/v2.5.4/src/MailChimp.php#L107