### PR TITLE
Ensure the last action succeeded on `isSubscribed`

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -96,7 +96,7 @@ class Newsletter
     {
         $response = $this->getMember($email, $listName);
 
-        if (! isset($response)) {
+        if (! $this->lastActionSucceeded()) {
             return false;
         }
 


### PR DESCRIPTION
The `getMember` action returns an `array` or `false`, so checking if it is not `isset` always evaluates to `false`.
Then we are checking if the `$response['status']` is equal to `subscribed`, which raises an error if the response is `false`.

This fixes #233 .