### PR TITLE
Add new method to format the last error returned from Mailchimp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-newsletter` will be documented in this file.
 
+## 4.8.3 - 2020-10-12
+
+- add new method for formatting API error response (As a fix for issue #237)
+
 ## 4.8.2 - 2020-09-30
 
 - ensure the last action succeeded on `isSubscribed` (#244)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ If something went wrong you can get the last error with:
 Newsletter::getLastError();
 ```
 
+You can get the last error as a formatted response. Error code, message and error data are in separate fields. So that your logics can handle errors accordingly. 
+```php
+Newsletter::getLastErrorFormatted(); //returns an array
+```
+
 If you just want to make sure if the last action succeeded you can use:
 ```php
 Newsletter::lastActionSucceeded(); //returns a boolean

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -280,4 +280,35 @@ class Newsletter
 
         return $options;
     }
+
+    /**
+     * This method formats the error response coming from the Mailchimp API.
+     * So that the errors are easily readable by the logics written by user and can be handled accordingly.
+     *
+     */
+    public function getLastErrorFormatted()
+    {
+        $api_response = $this->getLastError();
+
+        if($api_response != null && is_string($api_response)){
+            $api_response_arr = explode(": ", $api_response);
+            $error_code = isset($api_response_arr[0]) && is_numeric($api_response_arr[0]) ? $api_response_arr[0] : null;
+            $error_message = $api_response_arr[1] ?? null;
+
+            $error_data = [];
+            if($error_message != null && is_string($error_message)){
+                $pattern = '/[a-z0-9_\-\+\.]+@[a-z0-9\-]+\.([a-z]{2,4})(?:\.[a-z]{2})?/i';
+                preg_match_all($pattern, $error_message, $matches);
+                $error_data['emails'] = $matches[0];
+            }
+
+            return [
+                "error_code" => $error_code,
+                "error_message" => $error_message,
+                "error_data" => $error_data
+            ];
+        }
+
+        return $api_response;
+    }
 }

--- a/tests/MailChimp/LastErrorFormatterTest.php
+++ b/tests/MailChimp/LastErrorFormatterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spatie\Newsletter\Test;
+
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Spatie\Newsletter\Newsletter;
+use Spatie\Newsletter\NewsletterListCollection;
+use Spatie\Newsletter\NullDriver;
+use DrewM\MailChimp\MailChimp;
+
+class LastErrorFormatterTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Mockery\Mock */
+    protected $mailChimpApi;
+
+    /** @var \Spatie\Newsletter\Newsletter */
+    protected $newsletter;
+
+    public function setUp(): void
+    {
+        $this->mailChimpApi = Mockery::mock(MailChimp::class);
+
+        $newsletterLists = NewsletterListCollection::createFromConfig(
+            [
+                'lists' => [
+                    'list1' => ['id' => 123],
+                    'list2' => ['id' => 456],
+                ],
+                'defaultListName' => 'list1',
+            ]
+        );
+
+        $this->newsletter = new Newsletter($this->mailChimpApi, $newsletterLists);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        if ($container = Mockery::getContainer()) {
+            $this->addToAssertionCount($container->mockery_getExpectationCount());
+        }
+
+        Mockery::close();
+    }
+
+    /** @test */
+    public function it_can_format_last_error()
+    {
+        $this->mailChimpApi->shouldReceive('getLastErrorFormatted');
+    }
+}


### PR DESCRIPTION
### New method for a better error handling

I added a new method for formatting the last error returned from Mailchimp. 

The current method only returns the plain string returned by Mailchimp API. 

```
Newsletter::getLastError();
```

This will return,

```
400: rincewind@discworld.com is already a list member. Use PUT to insert or update list members.
```

It contains,
- status code
- error message
- some useful user date (Eg: emails)

All these information are in a single line of string which is not quite useful for the end user or the developer. 

So, to overcome this problem I created a new method that formats the above response so that the developers can handle the error and do meaningful further actions based on that. And also provide user-friendly error messages to the end-user. 

### Newly added method

```
Newsletter::getLastErrorFormatted();
```

This will return,

```
[
  "error_code" => "400"
  "error_message" => "rincewind@discworld.com is already a list member. Use PUT to insert or update list members."
  "error_data" => [
    "emails" => [
      0 => "rincewind@discworld.com"
    ]
  ]
]
```

This can further be improved using pre defined error messages for certain responses. And so much more!

I created a separate branch for this. `feature-format-api-errors`.
I updated the documentation `README.md` and `CHANGELOG.md` as well.
I wrote a test as well but not sure in which event it should run with. I'd like to get some knowledge about it. 

So, hope you guys find this helpful and review this pull request. Please let me know if clarifications needed. (techzbuddy@gmail.com)

And if this meets the standards you're looking for in a pull request, I'd appreciate that if you label this PR with `hacktoberfest-accepted`.

Thanks!