### PR TITLE
Add method getallmembers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ In addition to this you can also check if a user is subscribed to your list:
 Newsletter::isSubscribed('lord.vetinari@discworld.com'); //returns a boolean
 ```
 
+You can get the members for a given list, optionally filtered by passing a second array of parameters. As documented in Mailchimp API, it'll return the first 10 results unless indicated otherwise:
+
+```php
+Newsletter::getMembers();
+```
+
+Also, you can retrieve the full list of members for a given list, paginating over the results. It retries if there's a failure (network, api), useful for large lists:
+
+```php
+Newsletter::getAllMembers();
+```
+
 ### Creating a campaign
 
 This the signature of `createCampaign`:

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Newsletter;
 
-use Exception;
 use DrewM\MailChimp\MailChimp;
+use Exception;
 
 class Newsletter
 {
@@ -78,7 +78,7 @@ class Newsletter
         $members = [];
 
         for ($i = 0; $i < $total; $i += 500) {
-            $payload = array_merge($parameters, ['count'  => 500, 'offset' => $i]);
+            $payload = array_merge($parameters, ['count' => 500, 'offset' => $i]);
 
             $members = array_merge(
                 $members,

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -617,4 +617,61 @@ class NewsletterTest extends TestCase
 
         $this->assertSame('the-post-response', $actual);
     }
+
+    /** @test */
+    public function it_can_get_the_list_of_all_members()
+    {
+        $this->mailChimpApi
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', []])->andReturn(['total_items' => 1501])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 0, 'count' => 500]])->andReturn(['members' => ['a']])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 500, 'count' => 500]])->andReturn(['members' => ['b']])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 1000, 'count' => 500]])->andReturn(['members' => ['c']])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 1500, 'count' => 500]])->andReturn(['members' => ['d']]);
+
+        $this->assertSame(['a', 'b', 'c', 'd'], $this->newsletter->getAllMembers());
+    }
+
+    /** @test */
+    public function it_retries_get_the_list_of_all_members()
+    {
+        require_once __DIR__.'/Sleep.php';
+
+        $this->mailChimpApi
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', []])->andReturn(['total_items' => 999])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 0, 'count' => 500]])->andReturn(['members' => ['a']])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 500, 'count' => 500]])->twice()->andThrow(new \Exception)
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 500, 'count' => 500]])->andReturn(['members' => ['b']]);
+
+        $this->assertSame(['a', 'b'], $this->newsletter->getAllMembers());
+    }
+
+    /** @test */
+    public function it_fails_get_the_list_of_all_members()
+    {
+        $this->expectException(\Exception::class);
+
+        require_once __DIR__.'/Sleep.php';
+
+        $this->mailChimpApi
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', []])->andReturn(['total_items' => 10])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 0, 'count' => 500]])->times(10)->andThrow(new \Exception);
+
+        $this->newsletter->getAllMembers();
+    }
+
+    /** @test */
+    public function it_fails_get_the_list_of_all_members2()
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('foo');
+
+        require_once __DIR__.'/Sleep.php';
+
+        $this->mailChimpApi
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', []])->andReturn(['total_items' => 10])
+            ->shouldReceive('get')->once()->withArgs(['lists/123/members', ['offset' => 0, 'count' => 500]])->times(10)->andReturn(null)
+            ->shouldReceive('getLastError')->times(10)->andReturn('foo');
+
+        $this->newsletter->getAllMembers();
+    }
 }

--- a/tests/MailChimp/Sleep.php
+++ b/tests/MailChimp/Sleep.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Newsletter;
+
+// @see https://php.net/manual/en/language.namespaces.fallback.php
+function sleep()
+{
+}


### PR DESCRIPTION
Reopen from https://github.com/spatie/laravel-newsletter/pull/202

I still think this has a a point

#161
#193

Add a method to retrieve all the members from a list