### PR TITLE
Provide last error as an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-newsletter` will be documented in this file.
 
+## 4.8.3 - 2020-10-23
+
+- Added `getLastErrorAsException` method
+
 ## 4.8.2 - 2020-09-30
 
 - ensure the last action succeeded on `isSubscribed` (#244)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ If something went wrong you can get the last error with:
 Newsletter::getLastError();
 ```
 
+You can get the last error as an exception object:
+```php
+Newsletter::getLastErrorAsException();
+```
+
 If you just want to make sure if the last action succeeded you can use:
 ```php
 Newsletter::lastActionSucceeded(); //returns a boolean

--- a/src/Exceptions/MailChimpClientException.php
+++ b/src/Exceptions/MailChimpClientException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\Newsletter\Exceptions;
+
+use Exception;
+
+class MailChimpClientException extends Exception
+{
+
+    /**
+     * @param string $error
+     * @return static
+     */
+    public static function fromClientString(string $error): self
+    {
+        $errorData = explode(': ', $error);
+
+        return new static($errorData[1], $errorData[0]);
+    }
+}

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -3,6 +3,7 @@
 namespace Spatie\Newsletter;
 
 use DrewM\MailChimp\MailChimp;
+use Spatie\Newsletter\Exceptions\MailChimpClientException;
 
 class Newsletter
 {
@@ -252,6 +253,18 @@ class Newsletter
     public function getLastError()
     {
         return $this->mailChimp->getLastError();
+    }
+
+    /**
+     * @return string|false|MailChimpClientException
+     */
+    public function getLastErrorAsException()
+    {
+        if ($error = $this->getLastError()) {
+            return MailChimpClientException::fromClientString($error);
+        }
+
+        return $error;
     }
 
     public function lastActionSucceeded(): bool

--- a/tests/MailChimp/MailChimpClientExceptionTest.php
+++ b/tests/MailChimp/MailChimpClientExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Newsletter\Test;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Newsletter\Exceptions\MailChimpClientException;
+
+class MailChimpClientExceptionTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_an_instance_through_error_string()
+    {
+        $exception = MailChimpClientException::fromClientString(
+            '400: Please provide a valid email address.'
+        );
+
+        $this->assertInstanceOf(MailChimpClientException::class, $exception);
+
+        $this->assertEquals(400, $exception->getCode());
+
+        $this->assertEquals('Please provide a valid email address.', $exception->getMessage());
+    }
+}

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Newsletter\Test;
 use DrewM\MailChimp\MailChimp;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use Spatie\Newsletter\Exceptions\MailChimpClientException;
 use Spatie\Newsletter\Newsletter;
 use Spatie\Newsletter\NewsletterListCollection;
 
@@ -616,5 +617,19 @@ class NewsletterTest extends TestCase
         $actual = $this->newsletter->removeTags(['tag-1', 'tag-2'], $email);
 
         $this->assertSame('the-post-response', $actual);
+    }
+
+    /** @test */
+    public function it_provides_last_error_as_exception()
+    {
+        $this->mailChimpApi->shouldReceive('getLastError')
+            ->once()
+            ->andReturn('400: Please provide a valid email address.');
+
+        $this->assertInstanceOf(
+            MailChimpClientException::class,
+            $this->newsletter->getLastErrorAsException()
+        );
+
     }
 }


### PR DESCRIPTION
Add new `Newsletter::getLastErrorAsException()` in order to better error handling. The exception object contains API error code and error message in a more encapsulated way.