### PR TITLE
GDPR Marketing Permissions

### DIFF
--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -40,6 +40,15 @@ return [
              * http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id.
              */
             'id' => env('MAILCHIMP_LIST_ID'),
+
+            /*
+             * The GDPR marketing permissions of this audience.
+             */
+            'marketing_permissions' => [
+                // 'email' => '2a4819ebc7',
+                // 'customized_online_advertising' => '4256fc7dc5',
+            ],
+
         ],
     ],
 

--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -43,6 +43,7 @@ return [
 
             /*
              * The GDPR marketing permissions of this audience.
+             * You can get a list of your permissions with this command: "php artisan newsletter:permissions"
              */
             'marketing_permissions' => [
                 // 'email' => '2a4819ebc7',

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -281,7 +281,7 @@ class Newsletter
         return $options;
     }
 
-    public function getMarketingPermissions(string $listName = ''): array
+    public function getMarketingPermissions(string $listName = '')
     {
         $list = $this->lists->findByName($listName);
 

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -280,4 +280,30 @@ class Newsletter
 
         return $options;
     }
+
+    public function setMarketingPermission(string $email, string $permission, bool $bool, string $listName = '')
+    {
+        $list = $this->lists->findByName($listName);
+
+        $id = $list->getMarketingPermission($permission);
+
+        $permissions = [
+            "marketing_permissions" => [
+                [
+                    "marketing_permission_id" => $id,
+                    "enabled" => $bool,
+                ],
+            ],
+        ];
+
+        $options = $this->getSubscriptionOptions($email, [], $permissions);
+
+        $response = $this->mailChimp->put("lists/{$list->getId()}/members/{$this->getSubscriberHash($email)}", $options);
+
+        if (! $this->lastActionSucceeded()) {
+            return false;
+        }
+
+        return $response;
+    }
 }

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -281,6 +281,28 @@ class Newsletter
         return $options;
     }
 
+    public function getMarketingPermissions(string $listName = ''): array
+    {
+        $list = $this->lists->findByName($listName);
+
+        $response = $this->mailChimp->get("lists/{$list->getId()}/members");
+
+        if (! $this->lastActionSucceeded()) {
+            return false;
+        }
+
+        $marketingPermissions = collect($response['members'][0]['marketing_permissions'])
+            ->map(function ($permission) {
+                return [
+                    'text' => $permission['text'],
+                    'id' => $permission['marketing_permission_id'],
+                ];
+            })
+            ->toArray();
+
+        return $marketingPermissions;
+    }
+
     public function setMarketingPermission(string $email, string $permission, bool $bool, string $listName = '')
     {
         $list = $this->lists->findByName($listName);

--- a/src/NewsletterList.php
+++ b/src/NewsletterList.php
@@ -25,4 +25,9 @@ class NewsletterList
     {
         return $this->name;
     }
+
+    public function getMarketingPermission(string $key): string
+    {
+        return $this->properties['marketing_permissions'][$key];
+    }
 }

--- a/src/NewsletterPermissions.php
+++ b/src/NewsletterPermissions.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spatie\Newsletter;
+
+use Illuminate\Console\Command;
+use Newsletter;
+
+class NewsletterPermissions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'newsletter:permissions {list?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get the marketing permissions of an audience';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $listName = $this->argument('list') ?? '';
+
+        $permissions = Newsletter::getMarketingPermissions($listName);
+
+        $this->table(
+            ['Marketing Permission', 'ID'],
+            $permissions
+        );
+    }
+}

--- a/src/NewsletterServiceProvider.php
+++ b/src/NewsletterServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\Newsletter;
 
 use DrewM\MailChimp\MailChimp;
 use Illuminate\Support\ServiceProvider;
+use Spatie\Newsletter\NewsletterPermissions;
 
 class NewsletterServiceProvider extends ServiceProvider
 {
@@ -36,5 +37,9 @@ class NewsletterServiceProvider extends ServiceProvider
         });
 
         $this->app->alias(Newsletter::class, 'newsletter');
+
+        $this->commands([
+            NewsletterPermissions::class,
+        ]);
     }
 }

--- a/tests/MailChimp/NewsletterListTest.php
+++ b/tests/MailChimp/NewsletterListTest.php
@@ -13,7 +13,12 @@ class NewsletterListTest extends TestCase
     {
         parent::setUp();
 
-        $this->newsletterList = new NewsletterList('subscriber', ['id' => 'abc123']);
+        $this->newsletterList = new NewsletterList('subscriber', [
+            'id' => 'abc123',
+            'marketing_permissions' => [
+                'email' => 'abc123'
+            ]
+        ]);
     }
 
     /** @test */
@@ -26,5 +31,11 @@ class NewsletterListTest extends TestCase
     public function it_can_determine_the_id_of_the_list()
     {
         $this->assertSame('abc123', $this->newsletterList->getId());
+    }
+
+    /** @test */
+    public function it_can_get_a_marketing_permission_of_the_list()
+    {
+        $this->assertSame('abc123', $this->newsletterList->getMarketingPermission('email'));
     }
 }


### PR DESCRIPTION
This PR provides an easy way to update a subscriber's GDRP marketing permissions. It also tackles issue #174.

## Get Marketing Permissions
Mailchimp doesn't provide an easy way to get your audience's marketing permission ID's. This PR adds an easy to use artisan command that outputs a nice table with the names of your audience's marketing permissions and their ID's. It will use the `defaultListName` by default. You can also provide a list of your choice

```bash
php artisan newsletter:permissions {list?}
```
<img width="454" alt="Bildschirmfoto 2021-04-23 um 3 03 42 PM" src="https://user-images.githubusercontent.com/23167701/115875034-19f33500-a445-11eb-96b7-1793edd744c1.png">

## Update Marketing Permission Config
Now that you know the permission names and ID's, you can add them to your list's config:
```php
'marketing_permissions' => [
    'email' => '2a4819ebc7',
    'customized_online_advertising' => '4256fc7dc5',
],
```

## Update A Subscriber's Marketing Permission
Now you can easily update a subscriber's marketing permission. The first argument is the email, the second argument the permission key from the config, the third argument a boolean to enable/disable the permission, and an optional fourth argument is a list name.
```php
Newsletter::setMarketingPermission('rincewind@discworld.com', 'email', false);
```

Please let me know what you think. This PR really speeds things up and helps to be on top of GDPR.




