### PR TITLE
Add get errors array

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ If something went wrong you can get the last error with:
 Newsletter::getLastError();
 ```
 
+Errors with fields will be in the errors array:
+```php
+Newsletter::getErrorsArray();
+/**
+ *    array:1 [
+ *        0 => array:2 [
+ *            "field" => "MMERGE1"
+ *            "message" => "Please enter the date"
+ *        ]
+ *    ]
+ */
+```
+
 If you just want to make sure if the last action succeeded you can use:
 ```php
 Newsletter::lastActionSucceeded(); //returns a boolean

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -254,6 +254,19 @@ class Newsletter
         return $this->mailChimp->getLastError();
     }
 
+    public function getErrorsArray()
+    {
+        $response = $this->mailChimp->getLastResponse();
+
+        if (! isset($response['body'])) {
+            return [];
+        }
+
+        $response = json_decode($response['body'], true);
+
+        return $response['errors'] ?? [];
+    }
+
     public function lastActionSucceeded(): bool
     {
         return $this->mailChimp->success();


### PR DESCRIPTION
This is helpful when you receive an error from MailChimp, especially when field types are not properly typed