### PR TITLE
Added a getList() method

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -56,6 +56,13 @@ class Newsletter
         return $response;
     }
 
+    public function getList(string $listName = '', array $parameters = [])
+    {
+        $list = $this->lists->findByName($listName);
+
+        return $this->mailChimp->get("lists/{$list->getId()}", $parameters);
+    }
+
     public function getMembers(string $listName = '', array $parameters = [])
     {
         $list = $this->lists->findByName($listName);

--- a/tests/MailChimp/NewsletterTest.php
+++ b/tests/MailChimp/NewsletterTest.php
@@ -440,6 +440,17 @@ class NewsletterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_list()
+    {
+        $this->mailChimpApi
+            ->shouldReceive('get')
+            ->once()
+            ->withArgs(['lists/123', []]);
+
+        $this->newsletter->getList();
+    }
+
+    /** @test */
     public function it_can_get_the_list_members()
     {
         $this->mailChimpApi


### PR DESCRIPTION
Hey! This PR is only a small one, but I thought it might be pretty handy for cleaning up some code that I have.

To give a bit of context, I have a scheduled command that runs every day and sends me a little report about my newsletter (such as the member count). At the moment, my code looks similar to this:

```php
// Before...

$listInfo = Newsletter::getApi()->get('lists/'.config('newsletter.lists.subscribers.id'));

$memberCount = $listInfo['stats']['member_count'];
```

But with the change in my PR, it could be clean up to look more like this:

```php
// After...

$memberCount = Newsletter::getList()['stats']['member_count'];
```

I'm hoping that I've not missed anything off. But if this is something that you might consider merging and it needs any changes, give me a shout and I'll make them ASAP 😄 