### PR TITLE
Fix exception thrown when command failed to load permissions 

### DIFF
--- a/src/NewsletterPermissions.php
+++ b/src/NewsletterPermissions.php
@@ -24,7 +24,7 @@ class NewsletterPermissions extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int
      */
     public function handle()
     {
@@ -32,9 +32,15 @@ class NewsletterPermissions extends Command
 
         $permissions = Newsletter::getMarketingPermissions($listName);
 
+        if (! $permissions) {
+            return Command::FAILURE;
+        }
+
         $this->table(
             ['Marketing Permission', 'ID'],
             $permissions
         );
+
+        return Command::SUCCESS;
     }
 }

--- a/src/NewsletterPermissions.php
+++ b/src/NewsletterPermissions.php
@@ -33,6 +33,8 @@ class NewsletterPermissions extends Command
         $permissions = Newsletter::getMarketingPermissions($listName);
 
         if (! $permissions) {
+            $this->error('Permissions Failed');
+
             return Command::FAILURE;
         }
 


### PR DESCRIPTION
The issue is when `Newsletter::getMarketingPermissions($listName);` fails and return `false` for any reason as List id was incorrect an error is being thrown 
```
Argument 1 passed to Symfony\Component\Console\Helper\Table::setRows() must be of the type array, bool given, called in /Users/mostafaakram/Sites/34apps/vendor/laravel/framework/src/Illuminate/Console/Concerns/InteractsWithIO.p  
  hp on line 232
```

And thats because `$this-table()` expects `array` as the second argument but `false` has been sent to it 

So i have just added condition to guard on this and return `Command::FAILURE;` if permission failed to be loaded 