### PR TITLE
Allow callable api key config

### DIFF
--- a/src/NewsletterServiceProvider.php
+++ b/src/NewsletterServiceProvider.php
@@ -26,7 +26,12 @@ class NewsletterServiceProvider extends ServiceProvider
                 return new NullDriver($driver === 'log');
             }
 
-            $mailChimp = new Mailchimp(config('newsletter.apiKey'));
+            $apiKey = config('newsletter.apiKey');
+            if (is_callable($apiKey)) {
+                $apiKey = $apiKey();
+            }
+
+            $mailChimp = new Mailchimp($apiKey);
 
             $mailChimp->verify_ssl = config('newsletter.ssl', true);
 


### PR DESCRIPTION
Hello!

This functionality is useful in situations where the api key is configurable outside of the config file, e.g. by using [optimistdigital/nova-settings](https://github.com/optimistdigital/nova-settings). I was running into this problem myself, which I solved by overriding the `Newsletter` singleton, but since that's not the most elegant solution and because this addition might be useful for others too, I decided to create a PR for it!

An example usage that will be possible with this change:

```
'apiKey' => static fn () => nova_get_setting('mailchimp_api_key')
```

I hope my contribution is useful!