### PR TITLE
Update 'Using mailchimp' readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The `driver` key of the `newsletter` config file must be set to `Spatie\Newslett
 
 Next, you must provide values for the API key and `list.subscribers.id`. You'll find these values in the MailChimp UI.
 
-The `endpoint` config value can be set to an empty string.
+The `endpoint` config value must be set to null.
 
 ## Usage
 


### PR DESCRIPTION
While using your package, I followed the instructions, but I was always getting empty responses and I couldn't get any information from getLastError() or getLastResponse(). I ran the code step by step and found that if NEWSLETTER_ENDPOINT is set to an empty string as the documentation states, the Mailchimp endpoint isn't built correctly. The solution is to set that value to null instead.