### PR TITLE
Update README.md to clarify the env variable setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,17 @@ To use MailChimp, install this extra package.
 composer require drewm/mailchimp-api
 ```
 
-The `driver` key of the `newsletter` config file must be set to `Spatie\Newsletter\Drivers\MailChimpDriver::class`.
+The `driver` key of the `newsletter` config file must be set to `Spatie\Newsletter\Drivers\MailChimpDriver::class`
+
+```
+'driver' => env('NEWSLETTER_DRIVER', Spatie\Newsletter\Drivers\MailChimpDriver::class),
+```
+
+or the `.env` variable must be set.
+
+```
+NEWSLETTER_DRIVER=Spatie\Newsletter\Drivers\MailChimpDriver
+```
 
 Next, you must provide values for the API key and `list.subscribers.id`. You'll find these values in the MailChimp UI.
 


### PR DESCRIPTION
I was getting the following error and couldn't figure out what was causing it. I realized after much head scratching that I was just stupid and was setting my env variable to 

```
NEWSLETTER_DRIVER =Spatie\Newsletter\Drivers\MailChimpDriver::class
```

which caused the following error. 

```
Error Class "Spatie\Newsletter\Drivers\MailChimpDriver::class" not found 
    vendor/spatie/laravel-newsletter/src/NewsletterServiceProvider.php:28 Spatie\Newsletter\NewsletterServiceProvider::Spatie\Newsletter\{closure}
    vendor/laravel/framework/src/Illuminate/Container/Container.php:885 Illuminate\Container\Container::build
    vendor/laravel/framework/src/Illuminate/Container/Container.php:770 Illuminate\Container\Container::resolve
    vendor/laravel/framework/src/Illuminate/Foundation/Application.php:856 Illuminate\Foundation\Application::resolve
    vendor/laravel/framework/src/Illuminate/Container/Container.php:706 Illuminate\Container\Container::make
    vendor/laravel/framework/src/Illuminate/Foundation/Application.php:841 Illuminate\Foundation\Application::make
    vendor/laravel/framework/src/Illuminate/Container/Container.php:1431 Illuminate\Container\Container::offsetGet
    vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:222 Illuminate\Support\Facades\Facade::resolveFacadeInstance
    vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:193 Illuminate\Support\Facades\Facade::getFacadeRoot
    vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:332 Illuminate\Support\Facades\Facade::__callStatic
```

I updated the Readme.md to clarify. It would have saved me and hour or so of digging around.

Just a thought.