### PR TITLE
Add method chaining support to NullDriver

### DIFF
--- a/src/Drivers/NullDriver.php
+++ b/src/Drivers/NullDriver.php
@@ -20,6 +20,15 @@ class NullDriver
     {
         if ($this->logCalls) {
             Log::debug('Called Spatie Newsletter facade method: '.$name.' with:', $arguments);
+
+            return new self;
         }
+
+        return $this;
+    }
+
+    public function __toString()
+    {
+        return '';
     }
 }


### PR DESCRIPTION
I'm tagging subscribers in a few places with code like this:

```
$hash = Newsletter::getApi()->subscriberHash($user->email);
Newsletter::getApi()->post("lists/123/members/{$hash}/tags", [
    'tags' => [['name' => 'My Tag', 'status' => 'active']],
]);
```

In a local or testing environment I have `NEWSLETTER_DRIVER=null` set in my `.env`. However this causes `getApi()->subscriberHash()` to throw an exception since `getApi()` returns `null` when a Newsletter driver is not set.

This PR ensures `NullDriver` return itself when a method is called so that method calls can be chained. `getApi()->subscriberHash()` will now return an instance of `NullDriver` instead of throwing.