### PR TITLE
Update facade docblock

### DIFF
--- a/src/Facades/Newsletter.php
+++ b/src/Facades/Newsletter.php
@@ -9,8 +9,8 @@ use Spatie\MailcoachSdk\Mailcoach;
 /**
  * Newsletter Facade
  *
- * @method static array|bool subscribe(string $email, array $mergeFields = [], string $listName = '', array $options = [])
- * @method static array|bool subscribeOrUpdate(string $email, array $mergeFields = [], string $listName = '', array $options = [])
+ * @method static array|bool subscribe(string $email, array $properties = [], string $listName = '', array $options = [])
+ * @method static array|bool subscribeOrUpdate(string $email, array $properties = [], string $listName = '', array $options = [])
  * @method static array|bool getMember(string $email, string $listName = '')
  * @method static bool hasMember(string $email, string $listName = '')
  * @method static bool isSubscribed(string $email, string $listName = '')


### PR DESCRIPTION
This pull request updates the `Newsletter` facade. The `$mergeFields` parameter was renamed to `$properties` in v5.