### PR TITLE
Add MailerLite driver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently this package support:
 
 - [Mailcoach](https://mailcoach.app) (built by us :-))
 - [MailChimp](https://mailchimp.com)
+- [MailerLite](https://mailerlite.com)
 
 ## Support us
 
@@ -88,6 +89,8 @@ return [
              *
              * When using the MailChimp driver, this should be a MailChimp list id.
              * http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id.
+             * 
+             * When using MailerLite Driver, this should be a MailerLite group ID
              */
             'id' => env('NEWSLETTER_LIST_ID'),
         ],
@@ -116,6 +119,20 @@ composer require drewm/mailchimp-api
 The `driver` key of the `newsletter` config file must be set to `Spatie\Newsletter\Drivers\MailChimpDriver::class`.
 
 Next, you must provide values for the API key and `list.subscribers.id`. You'll find these values in the MailChimp UI.
+
+The `endpoint` config value must be set to null.
+
+### Using MailerLite
+
+To use MailerLite, install this extra package.
+
+```bash
+composer require mailerlite/mailerlite-php
+```
+
+The `driver` key of the `newsletter` config file must be set to `Spatie\Newsletter\Drivers\MailerLiteDriver::class`.
+
+You need to provide the API key and the `group.id`. These can be found in your MailerLite Dashboard under Integrations > API.
 
 The `endpoint` config value must be set to null.
 
@@ -154,6 +171,11 @@ For MailChimp you can pass merge variables as the second argument:
 Newsletter::subscribe('rincewind@discworld.com', ['FNAME'=>'Rince', 'LNAME'=>'Wind']);
 ```
 
+For MailerLite you can pass subscriber fields as the second argument:
+```php
+Newsletter::subscribe('rincewind@discworld.com', ['name'=>'Rince', 'last_name'=>'Wind']);
+```
+
 You can subscribe someone to a specific list by passing a list name:
 ```php
 Newsletter::subscribe('rincewind@discworld.com', listName: 'subscribers');
@@ -181,6 +203,12 @@ Newsletter::subscribeOrUpdate(
 Simply add `false` if you want to remove someone from a group/interest.
 
 Here's how to unsubscribe someone from a specific list:
+
+```php
+Newsletter::unsubscribe('rincewind@discworld.com', 'subscribers');
+```
+
+For MailerLite, if you provide the group ID as the second argument, the subscriber will be removed from that group. Otherwise, they will be marked as unsubscribed.
 
 ```php
 Newsletter::unsubscribe('rincewind@discworld.com', 'subscribers');

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ return [
              *
              * When using the MailChimp driver, this should be a MailChimp list id.
              * http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id.
-             * 
-             * When using MailerLite Driver, this should be a MailerLite group ID
+             *
+             * When using the MailerLite driver, this should be a MailerLite group id.
              */
             'id' => env('NEWSLETTER_LIST_ID'),
         ],
@@ -208,11 +208,7 @@ Here's how to unsubscribe someone from a specific list:
 Newsletter::unsubscribe('rincewind@discworld.com', 'subscribers');
 ```
 
-For MailerLite, if you provide the group ID as the second argument, the subscriber will be removed from that group. Otherwise, they will be marked as unsubscribed.
-
-```php
-Newsletter::unsubscribe('rincewind@discworld.com', 'subscribers');
-```
+For MailerLite, passing a list name as the second argument removes the subscriber from the matching group. Without a list name, the subscriber is marked as unsubscribed across the account.
 
 ### Deleting subscribers
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
     "name": "spatie/laravel-newsletter",
-    "description": "Manage Mailcoach and MailChimp newsletters in Laravel",
+    "description": "Manage Mailcoach, MailChimp and MailerLite newsletters in Laravel",
     "keywords": [
         "laravel",
         "newsletter",
         "mailcoach",
-        "mailchimp"
+        "mailchimp",
+        "mailerlite"
     ],
     "homepage": "https://github.com/spatie/laravel-newsletter",
     "license": "MIT",
@@ -24,7 +25,8 @@
     },
     "suggest": {
         "spatie/mailcoach-sdk-php": "For working with Mailcoach",
-        "drewm/mailchimp-api": "For working with MailChimp"
+        "drewm/mailchimp-api": "For working with MailChimp",
+        "mailerlite/mailerlite-php": "For working with MailerLite"
     },
     "require-dev": {
         "drewm/mailchimp-api": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "drewm/mailchimp-api": "^2.5",
         "guzzlehttp/guzzle": "^7.5|^7.2",
+        "mailerlite/mailerlite-php": "^1.0",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^7.11|^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^1.20|^2.0|^3.0|^4.0",

--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -40,6 +40,8 @@ return [
              *
              * When using the MailChimp driver, this should be a MailChimp list id.
              * http://kb.mailchimp.com/lists/managing-subscribers/find-your-list-id.
+             *
+             * When using MailerLite Driver, this should be a MailerLite group ID
              */
             'id' => env('NEWSLETTER_LIST_ID'),
         ],

--- a/config/newsletter.php
+++ b/config/newsletter.php
@@ -1,5 +1,7 @@
 <?php
 
+use Spatie\Newsletter\Drivers\MailcoachDriver;
+
 return [
 
     /*
@@ -7,7 +9,7 @@ return [
      * You may use "log" or "null" to prevent calling the
      * API directly from your environment.
      */
-    'driver' => env('NEWSLETTER_DRIVER', Spatie\Newsletter\Drivers\MailcoachDriver::class),
+    'driver' => env('NEWSLETTER_DRIVER', MailcoachDriver::class),
 
     /**
      * These arguments will be given to the driver.

--- a/src/Drivers/MailerLiteDriver.php
+++ b/src/Drivers/MailerLiteDriver.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Spatie\Newsletter\Drivers;
+
+use MailerLite\MailerLite;
+use Spatie\Newsletter\Support\Lists;
+
+class MailerLiteDriver implements Driver
+{
+    protected MailerLite $mailerLite;
+    protected Lists $lists;
+
+    public static function make(array $arguments, Lists $lists): self
+    {
+        return new self($arguments, $lists);
+    }
+
+    public function __construct(array $arguments, Lists $lists)
+    {
+        $this->mailerLite = new MailerLite([
+            'api_key' => $arguments['api_key'] ?? ''
+        ]);
+
+        $this->lists = $lists;
+    }
+
+    public function getApi(): MailerLite
+    {
+        return $this->mailerLite;
+    }
+
+    public function subscribe(
+        string $email,
+        array $properties = [],
+        string $listName = '',
+        array $options = [],
+        bool $unsubscribe = false
+    ): array|false {
+        $groupId = $this->lists->findByName($listName)->getId();
+
+        try {
+            $response = $this->mailerLite->subscribers->create([
+                'email' => $email,
+                'groups' => [$groupId],
+                'fields' => $properties,
+                'status' => $unsubscribe ? 'unsubscribed' : null,
+            ]);
+
+            return $response['body']['data'] ?? false;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function subscribeOrUpdate(
+        string $email,
+        array $properties = [],
+        string $listName = '',
+        array $options = []
+    ): array|false {
+        return $this->subscribe($email, $properties, $listName, $options);
+    }
+
+    public function unsubscribe(string $email, string $listName = ''): array|false
+    {
+        if ($listName) {
+            $subscriber = $this->getMember($email, $listName);
+
+            if ($subscriber) {
+                $groupId = $this->lists->findByName($listName)->getId();
+                $this->mailerLite->groups->unAssignSubscriber($groupId, $subscriber['id']);
+
+                return $this->getMember($email);
+            }
+
+            return false;
+        }
+
+        return $this->subscribe($email, listName: $listName, unsubscribe: true);
+    }
+
+    public function delete(string $email, string $listName = ''): bool
+    {
+        $subscriber = $this->getMember($email, $listName);
+
+        if ($subscriber) {
+            try {
+                $this->mailerLite->subscribers->delete($subscriber['id']);
+                return true;
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    public function getMember(string $email, string $listName = ''): array|false
+    {
+        try {
+            $response = $this->mailerLite->subscribers->find($email);
+
+            $groupId = $this->lists->findByName($listName)->getId();
+
+            return $this->matchGroup($response, $groupId);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function hasMember(string $email, string $listName = ''): bool
+    {
+        return $this->getMember($email, $listName) !== false;
+    }
+
+    public function isSubscribed(string $email, string $listName = ''): bool
+    {
+        $subscriber = $this->getMember($email, $listName);
+
+        return $subscriber && ($subscriber['status'] ?? null) === 'active';
+    }
+
+    protected function matchGroup(array $subscriber, string|int $groupId): array|false
+    {
+        $groups = $subscriber['body']['data']['groups'] ?? [];
+
+        $groupIds = array_column($groups, 'id');
+
+        if (in_array($groupId, $groupIds, true)) {
+            return $subscriber['body']['data'];
+        }
+
+        return false;
+    }
+}

--- a/src/Drivers/MailerLiteDriver.php
+++ b/src/Drivers/MailerLiteDriver.php
@@ -2,13 +2,17 @@
 
 namespace Spatie\Newsletter\Drivers;
 
+use Exception;
 use MailerLite\MailerLite;
 use Spatie\Newsletter\Support\Lists;
 
 class MailerLiteDriver implements Driver
 {
     protected MailerLite $mailerLite;
+
     protected Lists $lists;
+
+    protected string|false $lastError = false;
 
     public static function make(array $arguments, Lists $lists): self
     {
@@ -18,7 +22,7 @@ class MailerLiteDriver implements Driver
     public function __construct(array $arguments, Lists $lists)
     {
         $this->mailerLite = new MailerLite([
-            'api_key' => $arguments['api_key'] ?? ''
+            'api_key' => $arguments['api_key'] ?? '',
         ]);
 
         $this->lists = $lists;
@@ -33,23 +37,9 @@ class MailerLiteDriver implements Driver
         string $email,
         array $properties = [],
         string $listName = '',
-        array $options = [],
-        bool $unsubscribe = false
+        array $options = []
     ): array|false {
-        $groupId = $this->lists->findByName($listName)->getId();
-
-        try {
-            $response = $this->mailerLite->subscribers->create([
-                'email' => $email,
-                'groups' => [$groupId],
-                'fields' => $properties,
-                'status' => $unsubscribe ? 'unsubscribed' : null,
-            ]);
-
-            return $response['body']['data'] ?? false;
-        } catch (\Exception $e) {
-            return false;
-        }
+        return $this->createSubscriber($email, $properties, $listName, $options);
     }
 
     public function subscribeOrUpdate(
@@ -58,54 +48,54 @@ class MailerLiteDriver implements Driver
         string $listName = '',
         array $options = []
     ): array|false {
-        return $this->subscribe($email, $properties, $listName, $options);
+        return $this->createSubscriber($email, $properties, $listName, $options);
     }
 
     public function unsubscribe(string $email, string $listName = ''): array|false
     {
-        if ($listName) {
-            $subscriber = $this->getMember($email, $listName);
+        $subscriber = $this->getMember($email, $listName);
 
-            if ($subscriber) {
-                $groupId = $this->lists->findByName($listName)->getId();
-                $this->mailerLite->groups->unAssignSubscriber($groupId, $subscriber['id']);
-
-                return $this->getMember($email);
-            }
-
+        if (! $subscriber) {
             return false;
         }
 
-        return $this->subscribe($email, listName: $listName, unsubscribe: true);
+        if ($listName !== '') {
+            return $this->tryRequest(function () use ($listName, $subscriber, $email) {
+                $groupId = $this->lists->findByName($listName)->getId();
+
+                $this->mailerLite->groups->unAssignSubscriber($groupId, $subscriber['id']);
+
+                return $this->getMember($email);
+            });
+        }
+
+        return $this->createSubscriber($email, [], $listName, ['status' => 'unsubscribed']);
     }
 
     public function delete(string $email, string $listName = ''): bool
     {
         $subscriber = $this->getMember($email, $listName);
 
-        if ($subscriber) {
-            try {
-                $this->mailerLite->subscribers->delete($subscriber['id']);
-                return true;
-            } catch (\Exception $e) {
-                return false;
-            }
+        if (! $subscriber) {
+            return false;
         }
 
-        return false;
+        return (bool) $this->tryRequest(function () use ($subscriber) {
+            $this->mailerLite->subscribers->delete($subscriber['id']);
+
+            return true;
+        });
     }
 
     public function getMember(string $email, string $listName = ''): array|false
     {
-        try {
+        return $this->tryRequest(function () use ($email, $listName) {
             $response = $this->mailerLite->subscribers->find($email);
 
             $groupId = $this->lists->findByName($listName)->getId();
 
             return $this->matchGroup($response, $groupId);
-        } catch (\Exception $e) {
-            return false;
-        }
+        });
     }
 
     public function hasMember(string $email, string $listName = ''): bool
@@ -118,6 +108,52 @@ class MailerLiteDriver implements Driver
         $subscriber = $this->getMember($email, $listName);
 
         return $subscriber && ($subscriber['status'] ?? null) === 'active';
+    }
+
+    public function getLastError(): string|false
+    {
+        return $this->lastError;
+    }
+
+    public function lastActionSucceeded(): bool
+    {
+        return $this->lastError === false;
+    }
+
+    protected function createSubscriber(
+        string $email,
+        array $properties,
+        string $listName,
+        array $options
+    ): array|false {
+        return $this->tryRequest(function () use ($email, $properties, $listName, $options) {
+            $groupId = $this->lists->findByName($listName)->getId();
+
+            $payload = array_merge([
+                'email' => $email,
+                'groups' => [$groupId],
+                'fields' => $properties,
+            ], $options);
+
+            $response = $this->mailerLite->subscribers->create($payload);
+
+            return $response['body']['data'] ?? false;
+        });
+    }
+
+    protected function tryRequest(callable $callback): mixed
+    {
+        try {
+            $result = $callback();
+
+            $this->lastError = false;
+
+            return $result;
+        } catch (Exception $exception) {
+            $this->lastError = $exception->getMessage();
+
+            return false;
+        }
     }
 
     protected function matchGroup(array $subscriber, string|int $groupId): array|false

--- a/tests/Drivers/MailerLiteDriverTest.php
+++ b/tests/Drivers/MailerLiteDriverTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use MailerLite\MailerLite;
+use Spatie\Newsletter\Drivers\MailerLiteDriver;
+use Spatie\Newsletter\Facades\Newsletter;
+
+it('can get the MailerLite API', function () {
+    config()->set('newsletter.driver', MailerLiteDriver::class);
+
+    expect(Newsletter::getApi())->toBeInstanceOf(MailerLite::class);
+});


### PR DESCRIPTION
Continuation of #346 by @gaurang404 (closed). His commits are preserved as the first two commits on this branch.

## Summary

- Adds a MailerLite driver implementing the `Driver` interface
- Adds `mailerlite/mailerlite-php` as a suggest + dev dependency
- Documents the new driver in the README

## Follow-up changes on top of @gaurang404's work

- Adds `getLastError()` and `lastActionSucceeded()` for parity with `MailChimpDriver`, so callers can introspect failures instead of only seeing `false`
- Routes every API call through a single `tryRequest()` helper so list-resolution failures (`findByName('')->getId()`) are also captured instead of escaping the silent-failure pattern
- Stops sending `status => null` on subscribe (only sets `status` when actually unsubscribing)
- Removes the extra `bool $unsubscribe = false` parameter from `subscribe()` since it widened the public signature beyond the `Driver` interface; uses `$options` instead
- README: drops a duplicate code example, fixes a trailing-whitespace line, tightens the MailerLite list-id description